### PR TITLE
Added the minVersion tag

### DIFF
--- a/common/src/main/resources/myrtrees-common.mixins.json
+++ b/common/src/main/resources/myrtrees-common.mixins.json
@@ -1,5 +1,6 @@
 {
   "required": true,
+  "minVersion": "0.8",
   "package": "io.alwa.mods.myrtrees.common.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [


### PR DESCRIPTION
I added this tag, so this error is being fixed:
```
[main/ERROR]: Mixin config myrtrees-common.mixins.json does not specify "minVersion" property
```